### PR TITLE
Use msg instead of task key on enqueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ s.add({
 })
 
 s.act({ role: 'queue', cmd: 'start' })
-s.act({ role: 'queue', cmd: 'enqueue', task: task })
+s.act({ role: 'queue', cmd: 'enqueue', msg: task })
 ```
 
 ## Usage in multiple processes
@@ -39,9 +39,9 @@ var s = require('seneca')()
             queues: ['q1', 'q2']
           })
 
-s.act({ role: 'queue', cmd: 'enqueue', task: { task: 'my task', param: 1 }})
-s.act({ role: 'queue', cmd: 'enqueue', task: { task: 'my task', param: 2 }})
-s.act({ role: 'queue', cmd: 'enqueue', task: { task: 'my task', param: 3 }})
+s.act({ role: 'queue', cmd: 'enqueue', msg: { task: 'my task', param: 1 }})
+s.act({ role: 'queue', cmd: 'enqueue', msg: { task: 'my task', param: 2 }})
+s.act({ role: 'queue', cmd: 'enqueue', msg: { task: 'my task', param: 3 }})
 ```
 
 ### server1

--- a/examples/in-process.js
+++ b/examples/in-process.js
@@ -18,4 +18,4 @@ s.add({
 
 console.log('worked if you see OK')
 s.act({ role: 'queue', cmd: 'start' })
-s.act({ role: 'queue', cmd: 'enqueue', task: task })
+s.act({ role: 'queue', cmd: 'enqueue', msg: task })

--- a/examples/out-process-client.js
+++ b/examples/out-process-client.js
@@ -5,6 +5,6 @@ var s = require('seneca')()
             queues: ['q1', 'q2']
           })
 
-s.act({ role: 'queue', cmd: 'enqueue', task: { task: 'my task', param: 1 }})
-s.act({ role: 'queue', cmd: 'enqueue', task: { task: 'my task', param: 2 }})
-s.act({ role: 'queue', cmd: 'enqueue', task: { task: 'my task', param: 3 }})
+s.act({ role: 'queue', cmd: 'enqueue', msg: { task: 'my task', param: 1 }})
+s.act({ role: 'queue', cmd: 'enqueue', msg: { task: 'my task', param: 2 }})
+s.act({ role: 'queue', cmd: 'enqueue', msg: { task: 'my task', param: 3 }})

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -27,10 +27,10 @@ function memory(role, seneca, options) {
     hook: 'enqueue',
     type: 'memory'
   }, function(args, done) {
-    if (!args.task) {
-      return done(new Error('no task specified'))
+    if (!args.msg) {
+      return done(new Error('no message specified'))
     }
-    queue.push(args.task)
+    queue.push(args.msg)
     done()
   })
 

--- a/test/memory.js
+++ b/test/memory.js
@@ -28,7 +28,7 @@ describe('seneca queue', function() {
 
     s.act({ role: 'queue', cmd: 'start' }, function(err) {
       if (err) { return done(err) }
-      s.act({ role: 'queue', cmd: 'enqueue', task: task }, function(err) {
+      s.act({ role: 'queue', cmd: 'enqueue', msg: task }, function(err) {
         if (err) { return done(err) }
       })
     })
@@ -41,7 +41,7 @@ describe('seneca queue', function() {
     }
 
     // first enqueing
-    s.act({ role: 'queue', cmd: 'enqueue', task: task })
+    s.act({ role: 'queue', cmd: 'enqueue', msg: task })
 
     // then we add the task handler
     s.add({
@@ -71,7 +71,7 @@ describe('seneca queue', function() {
 
     s.act({ role: 'queue', cmd: 'start' })
     s.act({ role: 'queue', cmd: 'stop' })
-    s.act({ role: 'queue', cmd: 'enqueue', task: task }, done)
+    s.act({ role: 'queue', cmd: 'enqueue', msg: task }, done)
   })
 
   it('should restart a worker', function(done) {
@@ -90,7 +90,7 @@ describe('seneca queue', function() {
 
     s.act({ role: 'queue', cmd: 'start' })
     s.act({ role: 'queue', cmd: 'stop' })
-    s.act({ role: 'queue', cmd: 'enqueue', task: task })
+    s.act({ role: 'queue', cmd: 'enqueue', msg: task })
     s.act({ role: 'queue', cmd: 'start' })
   })
 })

--- a/test/transport.js
+++ b/test/transport.js
@@ -65,7 +65,7 @@ describe('seneca queue', function() {
     server1.act({ role: 'queue', cmd: 'start' })
     server2.act({ role: 'queue', cmd: 'start' })
 
-    client.act({ role: 'queue', cmd: 'enqueue', task: task }, function(err) {
+    client.act({ role: 'queue', cmd: 'enqueue', msg: task }, function(err) {
       if (err) { return done(err) }
     })
   })
@@ -104,10 +104,10 @@ describe('seneca queue', function() {
     server1.act({ role: 'queue', cmd: 'start' })
     server2.act({ role: 'queue', cmd: 'start' })
 
-    client.act({ role: 'queue', cmd: 'enqueue', task: task1 }, function(err) {
+    client.act({ role: 'queue', cmd: 'enqueue', msg: task1 }, function(err) {
       if (err) { return done(err) }
     })
-    client.act({ role: 'queue', cmd: 'enqueue', task: task2 }, function(err) {
+    client.act({ role: 'queue', cmd: 'enqueue', msg: task2 }, function(err) {
       if (err) { return done(err) }
     })
   })


### PR DESCRIPTION
This helps both with consistency usually you send messages over queues and disambiguation (in the examples is common to see task used a key for the messages)
