### PR TITLE
Queue actions errors can not be all fatal

### DIFF
--- a/lib/memory.js
+++ b/lib/memory.js
@@ -4,7 +4,7 @@ var Async = require('async')
 
 module.exports = function memory (role, seneca, options) {
   function worker (task, done) {
-    seneca.act(task, done)
+    seneca.root.delegate({role$: role}).act(task, done)
   }
 
   var queue = Async.queue(worker, options.concurrency)

--- a/test/roles.test.js
+++ b/test/roles.test.js
@@ -135,7 +135,7 @@ describe('seneca queue', function () {
         task: 'my task'
       }, function (args, cb) {
         expect(args).to.include(task)
-        expect(args.plugin$).to.include({ tag: secondTime ? 'queue2' : 'queue1' })
+        expect(args.role$).to.equal(secondTime ? 'role2' : 'role1')
         cb()
 
         if (secondTime) {


### PR DESCRIPTION
I was trying something like the code in the end of this post

But, if I return a error from enqueued actions, it is a FATAL error and it shuts down the application and ends any concurrent tasks.

I do not think it make sense.

So I used seneca.root.delegate to change context.

It was necessary an adjustment on test.

I tried another approach adding a reference in the queue to the seneca instance provide by this keyword inside add function "role:role,hook:enqueue,type:memory" but not sure why it did not work.

The seneca instance used before was the one available in plugin function so it expected has fatal$:true, but the seneca instance from this keyword inside add function "role:role,hook:enqueue,type:memory" should not has fatal$: true, right?

seneca = (require 'seneca')
  timeout: 40*1000

seneca.use 'seneca-queue',
  role: 'cpu-intense-task-queue'
  concurrency: 1

plugin = (options) ->
  @add (init: 'cpu-intense-task'), (args,done) ->
    @log.info 'CPU intense task is up'
    done()
  @add (role: 'cpu-intense-task', cmd: 'execute'), (args,done) ->
    console.log "Starting #{args.task}"
    console.log args
    if args.fail
      console.log "#{args.task} failed"
      done (new Error "#{args.task} Failed ")
    else
      setTimeout ->
        console.log "Finished #{args.task}"
        done null, (task: args.task)
      , 6000
  'cpu-intense-task'

seneca.use plugin

seneca.act role: 'cpu-intense-task-queue', cmd: 'start'

console.log 'Seneca ready. Calling tasks every 3 seconds. Second is going to fail'
count = 0
timer = setInterval ->
  count++
  taskName = "Task #{count}"
  seneca.act
    role: 'cpu-intense-task-queue'
    cmd: 'enqueue'
    msg:
      role: 'cpu-intense-task'
      cmd: 'execute'
      task: taskName
      fail: count is 2
  , (err,args) ->
    if err
      console.log 'Failed to add #{taskName} to queue', err.message
    else
      console.log "Added #{taskName} to queue"
  clearInterval timer if count > 4
,3000
